### PR TITLE
Fix SEGV when growing the queue

### DIFF
--- a/c_src/brine_queue.c
+++ b/c_src/brine_queue.c
@@ -149,8 +149,8 @@ brine_queue_errors brine_queue_enqueue(brine_queue_s *queue, void* entry) {
 brine_queue_errors grow_queue(brine_queue_s *queue) {
   size_t index = 0;
   size_t count = 0;
-  size_t capacity = queue->capacity + (queue_entry_size * queue->growth_increment);
-  void ** data = enif_alloc(capacity);
+  size_t new_capacity = queue->capacity + queue->growth_increment;
+  void ** data = enif_alloc(new_capacity * queue_entry_size);
   if(data == NULL) {
     return BQ_NO_MEMORY;
   }
@@ -161,7 +161,7 @@ brine_queue_errors grow_queue(brine_queue_s *queue) {
   //delete old queue and fix meta data.
   enif_free(queue->data);
   queue->data = data;
-  queue->capacity *= 2;
+  queue->capacity = new_capacity;
   queue->start = 0;
   queue->end = queue->size; 
 


### PR DESCRIPTION
From https://github.com/kevsmith/brine/pull/4
- `queue->capacity` is in number of entries, not bytes, according to
  `brine_queue_new`. We shouldn't be using it as bytes here, nor
  assigning the new value (as bytes) to `queue->capacity`.
- It appears that the original growth calculation used `*= 2`, rather
  than `queue->growth_increment`. This appears to be the source of the
  bug. Unified the growth calculation to make this mistake harder to
  make in future.
